### PR TITLE
Fix #32 by appending ./ to relative imports from the same folder

### DIFF
--- a/src/utils/resolveImportPath.ts
+++ b/src/utils/resolveImportPath.ts
@@ -4,7 +4,7 @@ import { stripFileExtension } from './stripFileExtension';
 export function resolveImportPath(modulePath: string, containingFile: string) {
   containingFile = path.resolve(containingFile, '..');
   const strippedFile = stripFileExtension(path.relative(containingFile, modulePath));
-  if (strippedFile[0] !== '.') {
+  if (strippedFile.charAt(0) !== '.') {
     return `./${strippedFile}`;
   }
   return strippedFile;

--- a/src/utils/resolveImportPath.ts
+++ b/src/utils/resolveImportPath.ts
@@ -3,5 +3,9 @@ import { stripFileExtension } from './stripFileExtension';
 
 export function resolveImportPath(modulePath: string, containingFile: string) {
   containingFile = path.resolve(containingFile, '..');
-  return stripFileExtension(path.relative(containingFile, modulePath));
+  const strippedFile = stripFileExtension(path.relative(containingFile, modulePath));
+  if (strippedFile[0] !== '.') {
+    return `./${strippedFile}`;
+  }
+  return strippedFile;
 }

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -12,6 +12,13 @@ function getTmpFileName() {
   return path.resolve(tmpDir, `${++id}.test.generated.ts`);
 }
 
+function copyAndGetTmpFileName(fileToCopyPath: string, newFileName: string): string {
+  newFileName = `${++id}.test.${newFileName}`;
+  const newFilePath = path.resolve(tmpDir, newFileName);
+  fs.copyFileSync(fileToCopyPath, newFilePath, fs.constants.COPYFILE_EXCL);
+  return newFileName;
+}
+
 function cli(args: string[], cwd: string): Promise<{ error: ExecException | null; stdout: string; stderr: string }> {
   return new Promise((resolve) => {
     exec(
@@ -164,6 +171,34 @@ describe('CLI options testing', () => {
 
     expect(result.stdout).not.toContain('fetchBaseQuery');
     expect(result.stdout).toContain(`import { default as customBaseQuery } from \"test/fixtures/customBaseQuery\"`);
+
+    const expectedErrors = [MESSAGES.NAMED_EXPORT_MISSING];
+
+    const numberOfErrors = expectedErrors.filter((msg) => result.stderr.indexOf(msg) > -1).length;
+    expect(numberOfErrors).toEqual(0);
+  });
+
+  it("should import { default as customBaseQuery } from './customBaseQuery' when a local customBaseQuery is provided to --baseQuery", async () => {
+    const localBaseQueryName = copyAndGetTmpFileName('./test/fixtures/customBaseQuery.ts', 'localCustomBaseQuery.ts');
+    const fileName = getTmpFileName();
+    const result = await cli(
+      [
+        '-h',
+        `--baseQuery`,
+        `./test/tmp/${localBaseQueryName}:namedBaseQuery`,
+        '--file',
+        fileName,
+        `./test/fixtures/petstore.json`,
+      ],
+      '.'
+    );
+
+    const output = fs.readFileSync(fileName, { encoding: 'utf-8' });
+
+    const strippedLocalBaseQueryName = path.parse(localBaseQueryName).name;
+
+    expect(output).not.toContain('fetchBaseQuery');
+    expect(output).toContain(`import { namedBaseQuery } from './${strippedLocalBaseQueryName}'`);
 
     const expectedErrors = [MESSAGES.NAMED_EXPORT_MISSING];
 


### PR DESCRIPTION
When generating from docs using a custom baseQuery which is in the same folder as the output api.generated.ts file the resolveImportPath fails to append ./ to the start of the import path. Most likely because the path.relative call resolves the path to an empty string if the two directories are the same.

This fix that assumes that resolveImportPath is only called for relative imports, and ignores node modules which in my testing seems to be the case.

Written test and helper function to copy customBaseQuery into test/tmp folder and run a generate command using it. All tests pass successfully.