### PR TITLE
fix(generate): pass a baseQueryFn with --baseQuery

### DIFF
--- a/src/generate.ts
+++ b/src/generate.ts
@@ -50,6 +50,8 @@ export async function generateApi(
   const v3Doc = await getV3Doc(spec);
   if (typeof baseUrl !== 'string') {
     baseUrl = v3Doc.servers?.[0].url ?? 'https://example.com';
+  } else if (baseQuery !== 'fetchBaseQuery') {
+    console.warn(MESSAGES.BASE_URL_IGNORED);
   }
 
   const apiGen = new ApiGenerator(v3Doc, {});

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -137,7 +137,7 @@ export async function generateApi(
           exportName,
           reducerPath,
           createApiFn: factory.createIdentifier('createApi'),
-          baseQuery: baseQueryCall,
+          baseQuery: baseQuery === 'fetchBaseQuery' ? baseQueryCall : factory.createIdentifier(baseQuery),
           entityTypes: generateEntityTypes({ v3Doc, operationDefinitions }),
           endpointDefinitions: factory.createObjectLiteralExpression(
             operationDefinitions.map((operationDefinition) =>

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -112,18 +112,12 @@ export async function generateApi(
     });
   }
 
-  const generateBaseQueryCall = () =>
-    factory.createCallExpression(factory.createIdentifier(baseQuery), undefined, [
-      factory.createObjectLiteralExpression(
-        [
-          factory.createPropertyAssignment(
-            factory.createIdentifier('baseUrl'),
-            factory.createStringLiteral(baseUrl as string)
-          ),
-        ],
-        false
-      ),
-    ]);
+  const fetchBaseQueryCall = factory.createCallExpression(factory.createIdentifier('fetchBaseQuery'), undefined, [
+    factory.createObjectLiteralExpression(
+      [factory.createPropertyAssignment(factory.createIdentifier('baseUrl'), factory.createStringLiteral(baseUrl))],
+      false
+    ),
+  ]);
 
   const sourceCode = printer.printNode(
     ts.EmitHint.Unspecified,

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -112,17 +112,18 @@ export async function generateApi(
     });
   }
 
-  const baseQueryCall = factory.createCallExpression(factory.createIdentifier(baseQuery), undefined, [
-    factory.createObjectLiteralExpression(
-      [
-        factory.createPropertyAssignment(
-          factory.createIdentifier('baseUrl'),
-          factory.createStringLiteral(baseUrl as string)
-        ),
-      ],
-      false
-    ),
-  ]);
+  const generateBaseQueryCall = () =>
+    factory.createCallExpression(factory.createIdentifier(baseQuery), undefined, [
+      factory.createObjectLiteralExpression(
+        [
+          factory.createPropertyAssignment(
+            factory.createIdentifier('baseUrl'),
+            factory.createStringLiteral(baseUrl as string)
+          ),
+        ],
+        false
+      ),
+    ]);
 
   const sourceCode = printer.printNode(
     ts.EmitHint.Unspecified,
@@ -137,7 +138,7 @@ export async function generateApi(
           exportName,
           reducerPath,
           createApiFn: factory.createIdentifier('createApi'),
-          baseQuery: baseQuery === 'fetchBaseQuery' ? baseQueryCall : factory.createIdentifier(baseQuery),
+          baseQuery: baseQuery === 'fetchBaseQuery' ? generateBaseQueryCall() : factory.createIdentifier(baseQuery),
           entityTypes: generateEntityTypes({ v3Doc, operationDefinitions }),
           endpointDefinitions: factory.createObjectLiteralExpression(
             operationDefinitions.map((operationDefinition) =>

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -132,7 +132,7 @@ export async function generateApi(
           exportName,
           reducerPath,
           createApiFn: factory.createIdentifier('createApi'),
-          baseQuery: baseQuery === 'fetchBaseQuery' ? generateBaseQueryCall() : factory.createIdentifier(baseQuery),
+          baseQuery: baseQuery === 'fetchBaseQuery' ? fetchBaseQueryCall : factory.createIdentifier(baseQuery),
           entityTypes: generateEntityTypes({ v3Doc, operationDefinitions }),
           endpointDefinitions: factory.createObjectLiteralExpression(
             operationDefinitions.map((operationDefinition) =>

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -3,4 +3,5 @@ export const MESSAGES = {
   DEFAULT_EXPORT_MISSING: `Specified file exists, but no default export was found for the --baseQuery`,
   FILE_NOT_FOUND: `Unable to locate the specified file provided to --baseQuery`,
   TSCONFIG_FILE_NOT_FOUND: `Unable to locate the specified file provided to -c, --config`,
+  BASE_URL_IGNORED: `The url provided to --baseUrl is ignored when using --baseQuery`,
 };

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -88,6 +88,18 @@ describe('CLI options testing', () => {
     expect(numberOfHooks).toEqual(expectedHooks.length);
   });
 
+  it('should assign the specified baseQueryFn provided to --baseQuery', async () => {
+    const result = await cli(
+      [`--baseQuery`, `test/fixtures/customBaseQuery.ts:anotherNamedBaseQuery`, `./test/fixtures/petstore.json`],
+      '.'
+    );
+
+    const output = result.stdout;
+
+    expect(output).not.toContain('fetchBaseQuery');
+    expect(output).toContain('baseQuery: anotherNamedBaseQuery,');
+  });
+
   it('should error out when the specified filename provided to --baseQuery is not found', async () => {
     const result = await cli(
       ['-h', `--baseQuery`, `test/fixtures/nonExistantFile.ts`, `./test/fixtures/petstore.json`],

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -88,6 +88,14 @@ describe('CLI options testing', () => {
     expect(numberOfHooks).toEqual(expectedHooks.length);
   });
 
+  it('should call fetchBaseQuery with the url provided to --baseUrl', async () => {
+    const result = await cli([`--baseUrl`, `http://swagger.io`, `./test/fixtures/petstore.json`], '.');
+
+    const output = result.stdout;
+
+    expect(output).toContain('baseQuery: fetchBaseQuery({ baseUrl: "http://swagger.io" }),');
+  });
+
   it('should assign the specified baseQueryFn provided to --baseQuery', async () => {
     const result = await cli(
       [`--baseQuery`, `test/fixtures/customBaseQuery.ts:anotherNamedBaseQuery`, `./test/fixtures/petstore.json`],


### PR DESCRIPTION
## Fixes
Fixes #33 by @tevariou

## Description
When using the `--baseQuery` cli option like this `--baseQuery ./path/to/customBaseQuery.ts:customBaseQuery`, we get the following output:
```typescript
export const api = createApi({ baseQuery: customBaseQuery({ baseUrl: "https://example.com" }), ...})
```

 This PR changes the behaviour of the `--baseQuery` option and the output now would be:
```typescript
export const api = createApi({ baseQuery: customBaseQuery, ...})
```

The `--baseUrl` option now only apply if `--baseQuery` is not passed. In this case, the default `fetchBaseQuery` will be called with the specified base url.