### PR TITLE
RTK Query 0.3 support

### DIFF
--- a/test/__snapshots__/cli.test.ts.snap
+++ b/test/__snapshots__/cli.test.ts.snap
@@ -497,7 +497,8 @@ export type User = {
 `;
 
 exports[`CLI options testing should generate react hooks as a part of the output 1`] = `
-import { createApi, fetchBaseQuery } from "@rtk-incubator/rtk-query";
+import { createApi } from "@rtk-incubator/rtk-query/react";
+import { fetchBaseQuery } from "@rtk-incubator/rtk-query";
 export const api = createApi({
   baseQuery: fetchBaseQuery({ baseUrl: "/api/v3" }),
   entityTypes: [],

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -88,6 +88,16 @@ describe('CLI options testing', () => {
     expect(numberOfHooks).toEqual(expectedHooks.length);
   });
 
+  it('should contain the right imports when using hooks and a custom base query', async () => {
+    const result = await cli(
+      ['-h', `--baseQuery`, `test/fixtures/customBaseQuery.ts:anotherNamedBaseQuery`, `./test/fixtures/petstore.json`],
+      '.'
+    );
+
+    expect(result.stdout).toContain(`import { createApi } from \"@rtk-incubator/rtk-query/react\";`);
+    expect(result.stdout).toContain(`import { anotherNamedBaseQuery } from \"test/fixtures/customBaseQuery\";`);
+  });
+
   it('should call fetchBaseQuery with the url provided to --baseUrl', async () => {
     const result = await cli([`--baseUrl`, `http://swagger.io`, `./test/fixtures/petstore.json`], '.');
 


### PR DESCRIPTION
Adds support and tests for the `/react` entry point to go along with https://github.com/rtk-incubator/rtk-query/milestone/2