### PR TITLE
fix: rename entityTypes to tagTypes

### DIFF
--- a/src/codegen.ts
+++ b/src/codegen.ts
@@ -40,7 +40,7 @@ export function generateCreateApiCall({
   reducerPath,
   createApiFn,
   baseQuery,
-  entityTypes,
+  tagTypes,
   endpointBuilder = defaultEndpointBuilder,
   endpointDefinitions,
 }: {
@@ -48,7 +48,7 @@ export function generateCreateApiCall({
   reducerPath?: string;
   createApiFn: ts.Expression;
   baseQuery: ts.Expression;
-  entityTypes: ts.Expression;
+  tagTypes: ts.Expression;
   endpointBuilder?: ts.Identifier;
   endpointDefinitions: ts.ObjectLiteralExpression;
 }) {
@@ -65,7 +65,7 @@ export function generateCreateApiCall({
               generateObjectProperties({
                 ...(!reducerPath ? {} : { reducerPath: factory.createStringLiteral(reducerPath) }),
                 baseQuery,
-                entityTypes,
+                tagTypes,
                 endpoints: factory.createArrowFunction(
                   undefined,
                   undefined,

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -138,7 +138,7 @@ export async function generateApi(
           reducerPath,
           createApiFn: factory.createIdentifier('createApi'),
           baseQuery: baseQueryCall,
-          tagTypes: generatetagTypes({ v3Doc, operationDefinitions }),
+          tagTypes: generateTagTypes({ v3Doc, operationDefinitions }),
           endpointDefinitions: factory.createObjectLiteralExpression(
             operationDefinitions.map((operationDefinition) =>
               generateEndpoint({
@@ -160,7 +160,7 @@ export async function generateApi(
 
   return sourceCode;
 
-  function generatetagTypes(_: { operationDefinitions: OperationDefinition[]; v3Doc: OpenAPIV3.Document }) {
+  function generateTagTypes(_: { operationDefinitions: OperationDefinition[]; v3Doc: OpenAPIV3.Document }) {
     return generateStringLiteralArray([]); // TODO
   }
 

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -138,7 +138,7 @@ export async function generateApi(
           reducerPath,
           createApiFn: factory.createIdentifier('createApi'),
           baseQuery: baseQueryCall,
-          entityTypes: generateEntityTypes({ v3Doc, operationDefinitions }),
+          tagTypes: generatetagTypes({ v3Doc, operationDefinitions }),
           endpointDefinitions: factory.createObjectLiteralExpression(
             operationDefinitions.map((operationDefinition) =>
               generateEndpoint({
@@ -160,7 +160,7 @@ export async function generateApi(
 
   return sourceCode;
 
-  function generateEntityTypes(_: { operationDefinitions: OperationDefinition[]; v3Doc: OpenAPIV3.Document }) {
+  function generatetagTypes(_: { operationDefinitions: OperationDefinition[]; v3Doc: OpenAPIV3.Document }) {
     return generateStringLiteralArray([]); // TODO
   }
 

--- a/test/__snapshots__/cli.test.ts.snap
+++ b/test/__snapshots__/cli.test.ts.snap
@@ -4,7 +4,7 @@ exports[`CLI options testing should accept a valid url as the target swagger fil
 import { createApi, fetchBaseQuery } from "@rtk-incubator/rtk-query";
 export const api = createApi({
   baseQuery: fetchBaseQuery({ baseUrl: "/api/v3" }),
-  entityTypes: [],
+  tagTypes: [],
   endpoints: (build) => ({
     updatePet: build.mutation<UpdatePetApiResponse, UpdatePetApiArg>({
       query: (queryArg) => ({ url: \`/pet\`, method: "PUT", body: queryArg.pet }),
@@ -273,7 +273,7 @@ exports[`CLI options testing should create a file when --file is specified 1`] =
 import { createApi, fetchBaseQuery } from '@rtk-incubator/rtk-query';
 export const api = createApi({
   baseQuery: fetchBaseQuery({ baseUrl: '/api/v3' }),
-  entityTypes: [],
+  tagTypes: [],
   endpoints: (build) => ({
     getHealthcheck: build.query<GetHealthcheckApiResponse, GetHealthcheckApiArg>({
       query: () => ({ url: \`/healthcheck\` }),
@@ -501,7 +501,7 @@ import { createApi } from "@rtk-incubator/rtk-query/react";
 import { fetchBaseQuery } from "@rtk-incubator/rtk-query";
 export const api = createApi({
   baseQuery: fetchBaseQuery({ baseUrl: "/api/v3" }),
-  entityTypes: [],
+  tagTypes: [],
   endpoints: (build) => ({
     getHealthcheck: build.query<
       GetHealthcheckApiResponse,
@@ -802,7 +802,7 @@ exports[`CLI options testing should log output to the console when a filename is
 import { createApi, fetchBaseQuery } from "@rtk-incubator/rtk-query";
 export const api = createApi({
   baseQuery: fetchBaseQuery({ baseUrl: "/api/v3" }),
-  entityTypes: [],
+  tagTypes: [],
   endpoints: (build) => ({
     getHealthcheck: build.query<
       GetHealthcheckApiResponse,
@@ -1081,7 +1081,7 @@ exports[`yaml parsing should be able to use read a yaml file and create a file w
 import { createApi, fetchBaseQuery } from '@rtk-incubator/rtk-query';
 export const api = createApi({
   baseQuery: fetchBaseQuery({ baseUrl: '/api/v3' }),
-  entityTypes: [],
+  tagTypes: [],
   endpoints: (build) => ({
     updatePet: build.mutation<UpdatePetApiResponse, UpdatePetApiArg>({
       query: (queryArg) => ({ url: \`/pet\`, method: 'PUT', body: queryArg.pet }),
@@ -1301,7 +1301,7 @@ exports[`yaml parsing should parse a yaml schema from a URL 1`] = `
 import { createApi, fetchBaseQuery } from "@rtk-incubator/rtk-query";
 export const api = createApi({
   baseQuery: fetchBaseQuery({ baseUrl: "/api/v3" }),
-  entityTypes: [],
+  tagTypes: [],
   endpoints: (build) => ({
     updatePet: build.mutation<UpdatePetApiResponse, UpdatePetApiArg>({
       query: (queryArg) => ({ url: \`/pet\`, method: "PUT", body: queryArg.pet }),

--- a/test/fixtures/generated.ts
+++ b/test/fixtures/generated.ts
@@ -1,7 +1,7 @@
 import { createApi, fetchBaseQuery } from '@rtk-incubator/rtk-query';
 export const api = createApi({
   baseQuery: fetchBaseQuery({ baseUrl: '/api/v3' }),
-  entityTypes: [],
+  tagTypes: [],
   endpoints: (build) => ({
     getHealthcheck: build.query<GetHealthcheckApiResponse, GetHealthcheckApiArg>({
       query: () => ({ url: `/healthcheck` }),


### PR DESCRIPTION
The `createApi` property `entityTypes` is now `tagTypes`