### PR TITLE
Optionally quote query param names

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ npx @rtk-incubator/rtk-query-codegen-openapi --file generated.api.ts --baseQuery
 - `--baseUrl <url>` - set the `baseUrl` when using `fetchBaseQuery` (will be ignored if you pass `--baseQuery`)
 - `--hooks` - include React Hooks in the output (ex: `export const { useGetModelQuery, useUpdateModelMutation } = api`)
 - `--file <filename>` - specify a filename to output to (ex: `./generated.api.ts`)
+- `--quoteParameterNames` - Quotes the query parameter names, useful if generated names are `foo.bar`.
 
 ### Documentation
 

--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -23,6 +23,7 @@ program
   .option('-h, --hooks', 'generate React Hooks')
   .option('-c, --config <path>', 'pass tsconfig path for resolve path alias')
   .option('-f, --file <filename>', 'output file name (ex: generated.api.ts)')
+  .option('-q --quoteParameterNames', 'Add quotes to the generated parameter names')
   .parse(process.argv);
 
 if (program.args.length === 0) {
@@ -42,6 +43,7 @@ if (program.args.length === 0) {
     'hooks',
     'file',
     'config',
+    'quoteParameterNames',
   ] as const;
 
   const outputFile = program['file'];

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,4 +21,5 @@ export type GenerationOptions = {
   outputFile?: string;
   compilerOptions?: ts.CompilerOptions;
   isDataResponse?(code: string, response: OpenAPIV3.ResponseObject, allResponses: OpenAPIV3.ResponsesObject): boolean;
+  quoteParameterNames?: boolean;
 };

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -343,7 +343,7 @@ describe('CLI options testing', () => {
     expect(fs.readFileSync(fileName, { encoding: 'utf-8' })).toMatchSnapshot();
   });
 
-  it('should camel case parameters with full stops in their name', async () => {
+  it('should quote parameters when the -q flag is applied', async () => {
     const result = await cli(['-h', '-q', `./test/fixtures/list.json`], '.');
     expect(result.stdout).toContain(`params: { \"filter.id\": queryArg.filterId },`);
   });

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -342,6 +342,11 @@ describe('CLI options testing', () => {
 
     expect(fs.readFileSync(fileName, { encoding: 'utf-8' })).toMatchSnapshot();
   });
+
+  it('should camel case parameters with full stops in their name', async () => {
+    const result = await cli(['-h', '-q', `./test/fixtures/list.json`], '.');
+    expect(result.stdout).toContain(`params: { \"filter.id\": queryArg.filterId },`);
+  });
 });
 
 describe('yaml parsing', () => {

--- a/test/fixtures/list.json
+++ b/test/fixtures/list.json
@@ -1,0 +1,59 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Param test",
+    "version": "1"
+  },
+  "schemes": ["https"],
+  "consumes": ["application/json"],
+  "produces": ["application/json"],
+  "paths": {
+    "/api/v1/list": {
+      "get": {
+        "summary": "List things.",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/listResponse"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "filter.id",
+            "in": "query",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          }
+        ]
+      }
+    }
+  },
+  "definitions": {
+    "response": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "listResponse": {
+      "type": "object",
+      "properties": {
+        "allocations": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/response"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This MR adds a new command line argument `-q` which will quote all request parameter names.

This is an attempt to resolve the issue outlined in https://github.com/rtk-incubator/rtk-query-codegen/issues/35. Whilst there's been lots of improvements around camel casing and sanitizing other variables, obviously we can't do that for the parameter names.

For general users it should have no impact on the generated api.

I wasn't sure if it was best to append petstore.json to included a parameter name with a full stop in it, but in the end I decided for clarity a new swagger file might be better.

Let me know if there are any changes you would like me to make
