### PR TITLE
Generates void type when Request QueryArgs are empty.

### DIFF
--- a/src/generate.ts
+++ b/src/generate.ts
@@ -288,6 +288,8 @@ export async function generateApi(
       return name;
     };
 
+    const queryArgValues = Object.values(queryArg);
+
     const QueryArg = factory.createTypeReferenceNode(
       registerInterface(
         factory.createTypeAliasDeclaration(
@@ -295,22 +297,29 @@ export async function generateApi(
           [factory.createModifier(ts.SyntaxKind.ExportKeyword)],
           capitalize(getOperationName(verb, path, operation.operationId) + argSuffix),
           undefined,
-          factory.createTypeLiteralNode(
-            Object.values(queryArg).map((def) => {
-              const comment = def.origin === 'param' ? def.param.description : def.body.description;
-              const node = factory.createPropertySignature(
-                undefined,
-                propertyName(def.name),
-                createQuestionToken(!def.required),
-                def.type
-              );
+          queryArgValues.length > 0
+            ? factory.createTypeLiteralNode(
+                queryArgValues.map((def) => {
+                  const comment = def.origin === 'param' ? def.param.description : def.body.description;
+                  const node = factory.createPropertySignature(
+                    undefined,
+                    propertyName(def.name),
+                    createQuestionToken(!def.required),
+                    def.type
+                  );
 
-              if (comment) {
-                return ts.addSyntheticLeadingComment(node, ts.SyntaxKind.MultiLineCommentTrivia, `* ${comment} `, true);
-              }
-              return node;
-            })
-          )
+                  if (comment) {
+                    return ts.addSyntheticLeadingComment(
+                      node,
+                      ts.SyntaxKind.MultiLineCommentTrivia,
+                      `* ${comment} `,
+                      true
+                    );
+                  }
+                  return node;
+                })
+              )
+            : factory.createKeywordTypeNode(ts.SyntaxKind.VoidKeyword)
         )
       ).name
     );

--- a/test/__snapshots__/cli.test.ts.snap
+++ b/test/__snapshots__/cli.test.ts.snap
@@ -176,7 +176,7 @@ export type UploadFileApiArg = {
 export type GetInventoryApiResponse = /** status 200 successful operation */ {
   [key: string]: number;
 };
-export type GetInventoryApiArg = {};
+export type GetInventoryApiArg = void;
 export type PlaceOrderApiResponse = /** status 200 successful operation */ Order;
 export type PlaceOrderApiArg = {
   order: Order;
@@ -208,7 +208,7 @@ export type LoginUserApiArg = {
   password?: string;
 };
 export type LogoutUserApiResponse = unknown;
-export type LogoutUserApiArg = {};
+export type LogoutUserApiArg = void;
 export type GetUserByNameApiResponse = /** status 200 successful operation */ User;
 export type GetUserByNameApiArg = {
   /** The name that needs to be fetched. Use user1 for testing.  */
@@ -352,7 +352,7 @@ export const api = createApi({
 export type GetHealthcheckApiResponse = /** status 200 OK */ {
   message: string;
 };
-export type GetHealthcheckApiArg = {};
+export type GetHealthcheckApiArg = void;
 export type UpdatePetApiResponse = /** status 200 Successful operation */ Pet;
 export type UpdatePetApiArg = {
   /** Update an existent pet in the store */
@@ -404,7 +404,7 @@ export type UploadFileApiArg = {
 export type GetInventoryApiResponse = /** status 200 successful operation */ {
   [key: string]: number;
 };
-export type GetInventoryApiArg = {};
+export type GetInventoryApiArg = void;
 export type PlaceOrderApiResponse = /** status 200 successful operation */ Order;
 export type PlaceOrderApiArg = {
   order: Order;
@@ -436,7 +436,7 @@ export type LoginUserApiArg = {
   password?: string;
 };
 export type LogoutUserApiResponse = unknown;
-export type LogoutUserApiArg = {};
+export type LogoutUserApiArg = void;
 export type GetUserByNameApiResponse = /** status 200 successful operation */ User;
 export type GetUserByNameApiArg = {
   /** The name that needs to be fetched. Use user1 for testing.  */
@@ -631,7 +631,7 @@ export const api = createApi({
 export type GetHealthcheckApiResponse = /** status 200 OK */ {
   message: string;
 };
-export type GetHealthcheckApiArg = {};
+export type GetHealthcheckApiArg = void;
 export type UpdatePetApiResponse = /** status 200 Successful operation */ Pet;
 export type UpdatePetApiArg = {
   /** Update an existent pet in the store */
@@ -683,7 +683,7 @@ export type UploadFileApiArg = {
 export type GetInventoryApiResponse = /** status 200 successful operation */ {
   [key: string]: number;
 };
-export type GetInventoryApiArg = {};
+export type GetInventoryApiArg = void;
 export type PlaceOrderApiResponse = /** status 200 successful operation */ Order;
 export type PlaceOrderApiArg = {
   order: Order;
@@ -715,7 +715,7 @@ export type LoginUserApiArg = {
   password?: string;
 };
 export type LogoutUserApiResponse = unknown;
-export type LogoutUserApiArg = {};
+export type LogoutUserApiArg = void;
 export type GetUserByNameApiResponse = /** status 200 successful operation */ User;
 export type GetUserByNameApiArg = {
   /** The name that needs to be fetched. Use user1 for testing.  */
@@ -932,7 +932,7 @@ export const api = createApi({
 export type GetHealthcheckApiResponse = /** status 200 OK */ {
   message: string;
 };
-export type GetHealthcheckApiArg = {};
+export type GetHealthcheckApiArg = void;
 export type UpdatePetApiResponse = /** status 200 Successful operation */ Pet;
 export type UpdatePetApiArg = {
   /** Update an existent pet in the store */
@@ -984,7 +984,7 @@ export type UploadFileApiArg = {
 export type GetInventoryApiResponse = /** status 200 successful operation */ {
   [key: string]: number;
 };
-export type GetInventoryApiArg = {};
+export type GetInventoryApiArg = void;
 export type PlaceOrderApiResponse = /** status 200 successful operation */ Order;
 export type PlaceOrderApiArg = {
   order: Order;
@@ -1016,7 +1016,7 @@ export type LoginUserApiArg = {
   password?: string;
 };
 export type LogoutUserApiResponse = unknown;
-export type LogoutUserApiArg = {};
+export type LogoutUserApiArg = void;
 export type GetUserByNameApiResponse = /** status 200 successful operation */ User;
 export type GetUserByNameApiArg = {
   /** The name that needs to be fetched. Use user1 for testing.  */
@@ -1205,7 +1205,7 @@ export type UploadFileApiArg = {
 export type GetInventoryApiResponse = /** status 200 successful operation */ {
   [key: string]: number;
 };
-export type GetInventoryApiArg = {};
+export type GetInventoryApiArg = void;
 export type PlaceOrderApiResponse = /** status 200 successful operation */ Order;
 export type PlaceOrderApiArg = {
   order: Order;
@@ -1237,7 +1237,7 @@ export type LoginUserApiArg = {
   password?: string;
 };
 export type LogoutUserApiResponse = unknown;
-export type LogoutUserApiArg = {};
+export type LogoutUserApiArg = void;
 export type GetUserByNameApiResponse = /** status 200 successful operation */ User;
 export type GetUserByNameApiArg = {
   /** The name that needs to be fetched. Use user1 for testing.  */
@@ -1522,7 +1522,7 @@ export type UploadFileApiArg = {
 export type GetInventoryApiResponse = /** status 200 successful operation */ {
   [key: string]: number;
 };
-export type GetInventoryApiArg = {};
+export type GetInventoryApiArg = void;
 export type PlaceOrderApiResponse = /** status 200 successful operation */ Order;
 export type PlaceOrderApiArg = {
   order: Order;
@@ -1554,7 +1554,7 @@ export type LoginUserApiArg = {
   password?: string;
 };
 export type LogoutUserApiResponse = unknown;
-export type LogoutUserApiArg = {};
+export type LogoutUserApiArg = void;
 export type GetUserByNameApiResponse = /** status 200 successful operation */ User;
 export type GetUserByNameApiArg = {
   /** The name that needs to be fetched. Use user1 for testing.  */


### PR DESCRIPTION
Addresses issue as described in #53 

For cases where queryArgs don't exist, generate a void type instead of {}
❌  `type GetItemsApiArg = {};`
✅ `type GetItemsApiArg = void;`