### PR TITLE
Add option excludeEndpoints

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -53,14 +53,17 @@ export interface CommonOptions {
   hooks?: boolean;
 }
 
+export type Matcher = string | RegExp | (string | RegExp)[];
+
 export interface OutputFileOptions extends Partial<CommonOptions> {
   outputFile: string;
-  filterEndpoints?: string | RegExp | (string | RegExp)[];
+  filterEndpoints?: Matcher;
+  excludeEndpoints?: Matcher;
   endpointOverrides?: EndpointOverrides[];
 }
 
 export interface EndpointOverrides {
-  pattern: string | RegExp | (string | RegExp)[];
+  pattern: Matcher;
   type: 'mutation' | 'query';
 }
 

--- a/test/generateEndpoints.test.ts
+++ b/test/generateEndpoints.test.ts
@@ -18,6 +18,15 @@ test('endpoint filtering', async () => {
   expect(api).toMatchSnapshot('should only have endpoints loginUser, placeOrder, getOrderById, deleteOrder');
 });
 
+test('negated endpoint filtering', async () => {
+  const api = await generateEndpoints({
+    apiFile: './fixtures/emptyApi.ts',
+    schemaFile: resolve(__dirname, 'fixtures/petstore.json'),
+    excludeEndpoints: [/user/i],
+  });
+  expect(api).not.toMatch(/loginUser:/);
+});
+
 test('endpoint overrides', async () => {
   const api = await generateEndpoints({
     apiFile: './fixtures/emptyApi.ts',


### PR DESCRIPTION
Extends #81 with an extra option `excludeEndpoints` which works like `filterEndpoints` but in the opposite direction -- because negative matching with regular expressions is tough.